### PR TITLE
Windows EXE Executable Path of Python

### DIFF
--- a/install.rkt
+++ b/install.rkt
@@ -20,8 +20,13 @@
 
 ;; ----
 
+(define (new-find-executable-path p)
+  (find-executable-path (if (eq? (system-type 'os) 'windows)
+                            (string-append p ".exe")
+                            p)))
+
 (define (ipython-exe)
-  (or (find-executable-path "ipython")
+  (or (new-find-executable-path "ipython")
       (raise-user-error "Cannot find ipython configuration directory; try --ipython-dir")))
 
 (define (ipython-dir)


### PR DESCRIPTION
I tried to install iRacket inside Windows, and see the error that find-executable-path returns the path with UNIX file structure.

I wrote a new function (new-find-executable-path p) that returns the correct path for Windows OS`s, if python is it installed.